### PR TITLE
Misspelling in MD003

### DIFF
--- a/doc/Rules.md
+++ b/doc/Rules.md
@@ -88,7 +88,7 @@ Be consistent with the style of header used in a document:
 
     ## ATX style H2
 
-The setext_with_atx and settext_with_atx_closed doc styles allow atx-style
+The setext_with_atx and setext_with_atx_closed doc styles allow atx-style
 headers of level 3 or more in documents with setext style headers:
 
     Setext style H1


### PR DESCRIPTION
Misspelling in the description text for rule MD003.

Fixed so copy-and-paste can be done.